### PR TITLE
CI/CD fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
 
 branches:
   only:
+  - master
   - develop
 
 compiler:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,6 @@ cmake_minimum_required(VERSION 3.8)
 
 project(maximum-independent-set-parallel)
 
-#set(CMAKE_BINARY_DIR ${CMAKE_SOURCE_DIR}/build)
-#set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR})
-
 add_subdirectory(src)
 
 enable_testing()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ version: '1.0.{build}'
 #branches to build
 branches:
   only:
+    - master
     - develop
 
 #don't build on tags

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,18 +1,19 @@
 find_package(Boost COMPONENTS thread graph)
 
-include_directories(${Boost_INCLUDE_DIRS})
+add_library(MISLib STATIC 
+                finder.h
+                graph.cpp
+                finder_greedy.cpp
+                finder_brute.cpp
+                graph.h
+                finder_greedy.h
+                finder_brute.h)
 
-add_library(MISLib finder.h
-                   graph.cpp
-                   finder_greedy.cpp
-                   finder_brute.cpp
-                   graph.h
-                   finder_greedy.h
-                   finder_brute.h)
-
-target_link_libraries(MISLib ${Boost_LIBRARIES})
-
-add_executable(${PROJECT_NAME} main.cpp)
+target_include_directories(MISLib PUBLIC
+                            ${CMAKE_CURRENT_SOURCE_DIR}
+                            ${Boost_INCLUDE_DIRS})
+                
+target_link_libraries(MISLib PRIVATE ${Boost_LIBRARIES})
 
 #Treat warnings as errors
 if (MSVC)
@@ -20,6 +21,8 @@ if (MSVC)
 else()
     target_compile_options(MISLib PRIVATE -Wall -Wextra -pedantic -Werror)
 endif()
+
+add_executable(${PROJECT_NAME} main.cpp)
 
 set_target_properties(${PROJECT_NAME} MISLib PROPERTIES
     CXX_STANDARD 17

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,5 @@
 find_package(GTest REQUIRED)
 
-include_directories(${CMAKE_SOURCE_DIR}/src)
-
 add_executable(test_algo test_algo.cpp)
 
 set_target_properties(test_algo PROPERTIES


### PR DESCRIPTION
- Use target_include_libraries in CMake
- Build on master and develop branches